### PR TITLE
Record from first monitor listed by pacmd list by default and vorbis instead of mp3

### DIFF
--- a/rec.sh
+++ b/rec.sh
@@ -31,7 +31,7 @@ NOGUI=""
 SINPUT=$(pacmd list | sed -n "s/.*<\(.*\\.monitor\)>/\\1/p" | head -1)
 ##SOUND
 #if [ $# -gt 0 ]; then
-SOUNDC=" pulsesrc device=$SINPUT ! audio/x-raw,channels=2 ! multiqueue ! vorbisenc quality=0.4 ! multiqueue ! muxer."
+SOUNDC=" pulsesrc device-name=$SINPUT ! audio/x-raw,channels=2 ! multiqueue ! vorbisenc quality=0.4 ! multiqueue ! muxer."
 #echo "Sound ON"
 #else
 SOUND=" "


### PR DESCRIPTION
I don't know if there was a reason you chose mp3 over vorbis (perhaps latency?).
